### PR TITLE
added nose arguments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,10 @@
 [nosetests]
-verbosity=1
+verbosity=2
+with-spec=1
+spec-color=1
+with-coverage=1
+cover-erase=1
+cover-package=service
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
## What was changed
- Configured nose test arguments in setup.cfg
- Enabled spec output, color, coverage, cover erase, and service package coverage

## How to test
Run:

```bash
nosetests
